### PR TITLE
Infer return types from arrow functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		},
 		"testRegex": "/src/.*\\.spec\\.ts$",
 		"mapCoverage": true,
+		"testURL": "http://localhost/",
 		"coverageDirectory": "./coverage/",
 		"collectCoverageFrom": ["src/**/*.ts"],
 		"collectCoverage": true

--- a/src/execution.spec.ts
+++ b/src/execution.spec.ts
@@ -55,7 +55,7 @@ describe('Execution', () => {
 	});
 
 	describe('getModificationsForFile', () => {
-		it('should return 6 lines on test-data/basic.ts', () => {
+		it('should return 9 lines on test-data/basic.ts', () => {
 			const modifications = getModificationsForFile(
 				`${__dirname}/../test-data/basic.ts`,
 			);
@@ -73,6 +73,13 @@ describe('Execution', () => {
 					position: {
 						line: 13,
 						character: 25,
+					},
+				},
+				{
+					text: ': number',
+					position: {
+						line: 14,
+						character: 30,
 					},
 				},
 				{
@@ -101,6 +108,20 @@ describe('Execution', () => {
 					position: {
 						line: 35,
 						character: 21,
+					},
+				},
+				{
+					text: ': string',
+					position: {
+						line: 41,
+						character: 33,
+					},
+				},
+				{
+					text: ': string',
+					position: {
+						line: 46,
+						character: 11,
 					},
 				},
 			]);

--- a/src/execution.spec.ts
+++ b/src/execution.spec.ts
@@ -32,7 +32,7 @@ describe('Execution', () => {
 		it('should return two lines if cursor on basicFunction3', () => {
 			const modifications = getModificationsAtPosition(
 				`${__dirname}/../test-data/basic.ts`,
-				{ line: 22, character: 13 },
+				{ line: 22, character: 12 },
 			);
 
 			expect(modifications).toEqual([

--- a/src/models.ts
+++ b/src/models.ts
@@ -7,7 +7,7 @@ export interface ITsAutoReturnTypeResult {
 }
 
 export interface IVisitedFunction {
-	name: string;
+	name?: string;
 	inferredReturnType: string;
 	textToInsert: ITextToInsert | null;
 }

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -9,16 +9,16 @@ import { startNewExecution } from './executions';
 
 describe('Parser', () => {
 	describe('getFunctionNodes', () => {
-		it('should return 7 on basic.ts file', () => {
+		it('should return 11 on basic.ts file', () => {
 			const { selectedFile } = startNewExecution(
 				`${__dirname}/../test-data/basic.ts`,
 			);
 
 			const nodes = getFunctionNodes(selectedFile);
 
-			// basicFunction0, basicFunction1, basicFunction2, basicFunction3
-			// regularInnerFunction, basicFunction4, basicMethod
-			expect(nodes.length).toBe(7);
+			// basicFunction0, basicFunction1, basicFunction2, arrowInnerFunction, basicFunction3
+			// regularInnerFunction, basicFunction4, basicMethod, arrowFunction1, basicFunction5, arrowInnerFunction
+			expect(nodes.length).toBe(11);
 		});
 	});
 	describe('enrichFunctionNode', () => {
@@ -85,6 +85,16 @@ describe('Parser', () => {
 					},
 				},
 				{
+					inferredReturnType: 'number',
+					textToInsert: {
+						text: ': number',
+						position: {
+							line: 14,
+							character: 30,
+						},
+					},
+				},
+				{
 					name: 'basicFunction3',
 					inferredReturnType: 'number',
 					textToInsert: {
@@ -128,25 +138,34 @@ describe('Parser', () => {
 						},
 					},
 				},
+				{
+					inferredReturnType: 'string',
+					textToInsert: {
+						text: ': string',
+						position: {
+							line: 41,
+							character: 33,
+						},
+					},
+				},
+				{
+					inferredReturnType: 'void',
+					name: 'basicFunction5',
+					textToInsert: null,
+				},
+				{
+					inferredReturnType: 'string',
+					textToInsert: {
+						position: {
+							character: 11,
+							line: 46,
+						},
+						text: ': string',
+					},
+				},
 			] as IVisitedFunction[];
 
 			expect(enrichedFunctions).toEqual(expected);
-		});
-		it('should return an empty array if typeChecker cannot find symbol', () => {
-			const { selectedFile, typeChecker } = startNewExecution(
-				`${__dirname}/../test-data/basic.ts`,
-			);
-
-			typeChecker.getSymbolAtLocation = () => undefined;
-
-			const [firstNode] = getFunctionNodes(selectedFile);
-			const enrichedFunctions = enrichFunctionNode(
-				selectedFile,
-				firstNode,
-				typeChecker,
-			);
-
-			expect(enrichedFunctions).toEqual([]);
 		});
 	});
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,9 @@ export function isFunctionNode(
 	node: ts.Node,
 ): node is ts.FunctionDeclaration | ts.MethodDeclaration {
 	return (
-		ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)
+		ts.isFunctionDeclaration(node) ||
+		ts.isMethodDeclaration(node) ||
+		ts.isArrowFunction(node)
 	);
 }
 

--- a/test-data/basic.ts
+++ b/test-data/basic.ts
@@ -37,3 +37,12 @@ class A {
 		return 42;
 	}
 }
+
+// @ts-ignore
+const arrowFunction1 = (one, two) => 'string';
+
+// @ts-ignore
+function basicFunction5(): void {
+	let app: any;
+	app.use(() => 'string');
+}


### PR DESCRIPTION
Hi!

This is truly a great extension! I'd like to infer return types from arrow functions as well, therefore I added them to the parser. I also adjusted the tests a bit to ensure they run again.

Could you give this a try and potentially merge it into your extension? I added tests to cover the new use cases.

This was opened in response to [my issue](https://github.com/GuillaumeNury/vscode-ts-auto-return-type/issues/2)